### PR TITLE
Add local lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+super-linter.log

--- a/README.md
+++ b/README.md
@@ -17,6 +17,37 @@ This repository uses GitHub Actions to automate the following tasks:
   | JSX, TSX               | [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) |
 
 The workflow files can be found in the `.github/workflows/` directory.
+<br><br>
+
+## Running the Linter Locally
+
+To ensure code quality and consistency, we use Super-Linter. You can run the linter locally using the provided scripts:
+
+### On Unix-like systems (macOS, Linux):
+
+bash
+
+```
+./run-linter.sh
+```
+
+### On Windows:
+
+batch
+
+```
+run-linter.bat
+```
+
+Make sure you have Docker installed and running on your system before executing these commands.
+The linter is configured to check for:
+
+- JavaScript (ES)
+- TypeScript (ES)
+- JSX
+- TSX
+- Java
+  <br><br>
 
 ### Note:
 

--- a/run-linter.bat
+++ b/run-linter.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+rem Get the current directory
+set CURRENT_DIR=%~dp0
+
+rem Run the Super-Linter
+docker run ^
+-e LOG_LEVEL=ERROR ^
+-e RUN_LOCAL=true ^
+-e VALIDATE_JAVASCRIPT_ES=true ^
+-e VALIDATE_TYPESCRIPT_ES=true ^
+-e VALIDATE_JSX=true ^
+-e VALIDATE_TSX=true ^
+-e VALIDATE_JAVA=true ^
+-v "%CURRENT_DIR%:/tmp/lint" ^
+--rm ^
+ghcr.io/super-linter/super-linter:slim-v5.7.2
+
+endlocal

--- a/run-linter.sh
+++ b/run-linter.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Get the current directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run the Super-Linter
+docker run \
+  -e LOG_LEVEL=ERROR \
+  -e RUN_LOCAL=true \
+  -e VALIDATE_JAVASCRIPT_ES=true \
+  -e VALIDATE_TYPESCRIPT_ES=true \
+  -e VALIDATE_JSX=true \
+  -e VALIDATE_TSX=true \
+  -e VALIDATE_JAVA=true \
+  -e CREATE_LOG_FILE=true \
+  -v "${CURRENT_DIR}":/tmp/lint \
+  --rm \
+  ghcr.io/super-linter/super-linter:slim-v5.7.2


### PR DESCRIPTION
Instructions to run local linter is in the README file 

Requirements to run local linter:
- Docker installed

I am using an older version of super linter although the one used in GitHub Actions is the latest version. This is due to some error with running the latest version locally for Mac (refer to this [issue](https://github.com/super-linter/super-linter/issues/5070))

Let me know if there are any discrepancies between the local linter and GitHub Action if y'all do decide to use the local linter before pushing. *fingers crossed*