### PR TITLE
Fix wrong Dockerfile configuration

### DIFF
--- a/PeerPrep-UserService/user-service/Dockerfile
+++ b/PeerPrep-UserService/user-service/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM node:18 AS build
+FROM node:18-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   questionbank:
     build:


### PR DESCRIPTION
The mismatch in image for build and run stage caused the bcrypt library to fail when running /auth/login API.